### PR TITLE
Pin translations and theme to new home under open-sdg

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -27,7 +27,7 @@ jekyll_get_data:
   - data: schema
     json: 'https://norric1admin.github.io/sdg-data/meta/schema.json'
   - data: translations
-    json: 'https://opendataenterprise.github.io/sdg-translations/translations.json'
+    json: 'https://open-sdg.github.io/sdg-translations/translations-0.3.0.json'
 
 analytics:
   ga_prod: ''
@@ -86,4 +86,4 @@ defaults:
 plugins:
   - jekyll-remote-theme
 
-remote_theme: brockfanning/sdg-theme@multilingual
+remote_theme: open-sdg/open-sdg@0.1.0

--- a/_config_prod.yml
+++ b/_config_prod.yml
@@ -28,7 +28,7 @@ jekyll_get_data:
     json: 'https://sustainabledevelopment-chuck.github.io/sdg-data/meta/schema.json'
   - data: translations
     # Pin to version 0.2.0 of the translation repository.
-    json: 'https://opendataenterprise.github.io/sdg-translations/translations-0.2.0.json'
+    json: 'https://open-sdg.github.io/sdg-translations/translations-0.3.0.json'
 
 analytics:
   ga_prod: 'UA-108503280-1'
@@ -85,4 +85,4 @@ defaults:
 plugins:
   - jekyll-remote-theme
 
-remote_theme: brockfanning/sdg-theme@multilingual
+remote_theme: open-sdg/open-sdg@0.1.0


### PR DESCRIPTION
This update is needed because repositories have been moved into the open-sdg organisation.